### PR TITLE
Use .npmignore instead of files in package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-examples/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+examples/

--- a/package.json
+++ b/package.json
@@ -3,13 +3,6 @@
   "version": "1.0.19",
   "description": "JavaScript powered HTML5 Canvas based graphing library",
   "main": "src/engine.js",
-  "files": [
-    "src/engine.js",
-    "src/linegraph.js",
-    "src/piegraph.js",
-    "src/bargraph.js",
-    "src/helper.js"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/krystal/graphene.git"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.19",
   "description": "JavaScript powered HTML5 Canvas based graphing library",
   "main": "src/engine.js",
+  "files": [
+    "src/**/*"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/krystal/graphene.git"


### PR DESCRIPTION
The files whitelist means that whenever a new file is added we need to remember to include the file. Specifically the `.d.ts` file was not added to the files array.

Using the .npmignore blacklist we can exclude the files we don't want included in the final install while, not having to worry about including new files in the future